### PR TITLE
[#147757345] Fix api paths

### DIFF
--- a/src/main/java/it/trade/api/TradeItApi.java
+++ b/src/main/java/it/trade/api/TradeItApi.java
@@ -8,63 +8,63 @@ import retrofit2.http.Body;
 import retrofit2.http.POST;
 
 public interface TradeItApi {
-    @POST("/api/v2/user/getOAuthLoginPopupUrlForWebApp")
+    @POST("api/v2/user/getOAuthLoginPopupUrlForWebApp")
     Call<TradeItOAuthLoginPopupUrlForWebAppResponse> getOAuthLoginPopupUrlForWebApp(@Body TradeItOAuthLoginPopupUrlForWebAppRequest request);
 
-    @POST("/api/v2/user/getOAuthLoginPopupUrlForMobile")
+    @POST("api/v2/user/getOAuthLoginPopupUrlForMobile")
     Call<TradeItOAuthLoginPopupUrlForMobileResponse> getOAuthLoginPopupUrlForMobile(@Body TradeItOAuthLoginPopupUrlForMobileRequest request);
 
-    @POST("/api/v2/user/getOAuthLoginPopupURLForTokenUpdate")
+    @POST("api/v2/user/getOAuthLoginPopupURLForTokenUpdate")
     Call<TradeItOAuthLoginPopupUrlForTokenUpdateResponse> getOAuthLoginPopupURLForTokenUpdate(@Body TradeItOAuthLoginPopupUrlForTokenUpdateRequest request);
 
-    @POST("/api/v2/user/getOAuthAccessToken")
+    @POST("api/v2/user/getOAuthAccessToken")
     Call<TradeItOAuthAccessTokenResponse> getOAuthAccessToken(@Body TradeItOAuthAccessTokenRequest request);
 
-    @POST("/api/v2/user/oAuthLink")
+    @POST("api/v2/user/oAuthLink")
     Call<TradeItLinkLoginResponse> linkLogin(@Body TradeItLinkLoginRequest request);
 
-    @POST("/api/v2/user/oAuthUpdate")
+    @POST("api/v2/user/oAuthUpdate")
     Call<TradeItLinkLoginResponse> relinkLogin(@Body TradeItRelinkLoginRequest request);
 
-    @POST("/api/v2/preference/getStocksOrEtfsBrokerList")
+    @POST("api/v2/preference/getStocksOrEtfsBrokerList")
     Call<TradeItAvailableBrokersResponse> getAvailableBrokers(@Body TradeItRequestWithKey request);
 
-    @POST("/api/v2/user/oAuthDelete")
+    @POST("api/v2/user/oAuthDelete")
     Call<TradeItResponse> unlinkLogin(@Body TradeItUnlinkLoginRequest request);
 
-    @POST("/api/v2/user/authenticate")
+    @POST("api/v2/user/authenticate")
     Call<TradeItAuthenticateResponse> authenticate(@Body TradeItAuthenticateRequest request);
 
-    @POST("/api/v2/user/closeSession")
+    @POST("api/v2/user/closeSession")
     Call<TradeItResponse> closeSession(@Body TradeItRequestWithSession request);
 
-    @POST("/api/v2/user/answerSecurityQuestion")
+    @POST("api/v2/user/answerSecurityQuestion")
     Call<TradeItAuthenticateResponse> answerSecurityQuestion(@Body TradeItAnswerSecurityQuestionRequest request);
 
-    @POST("/api/v2/user/keepSessionAlive")
+    @POST("api/v2/user/keepSessionAlive")
     Call<TradeItResponse> keepSessionAlive(@Body TradeItRequestWithSession request);
 
-    @POST("/api/v2/order/previewStockOrEtfOrder")
+    @POST("api/v2/order/previewStockOrEtfOrder")
     Call<TradeItPreviewStockOrEtfOrderResponse> previewStockOrEtfOrder(@Body TradeItPreviewStockOrEtfOrderRequest request);
 
-    @POST("/api/v2/order/placeStockOrEtfOrder")
+    @POST("api/v2/order/placeStockOrEtfOrder")
     Call<TradeItPlaceStockOrEtfOrderResponse> placeStockOrEtfOrder(@Body TradeItPlaceStockOrEtfOrderRequest request);
 
-    @POST("/api/v2/balance/getAccountOverview")
+    @POST("api/v2/balance/getAccountOverview")
     Call<TradeItAccountOverviewResponse> getAccountOverview(@Body TradeItGetAccountOverviewRequest request);
 
-    @POST("/api/v2/position/getPositions")
+    @POST("api/v2/position/getPositions")
     Call<TradeItGetPositionsResponse> getPositions(@Body TradeItGetPositionsRequest request);
 
-    @POST("/api/v2/order/getAllOrderStatus")
+    @POST("api/v2/order/getAllOrderStatus")
     Call<TradeItOrderStatusResponse> getAllOrderStatus(@Body TradeItGetAllOrderStatusRequest request);
 
-    @POST("/api/v2/order/getSingleOrderStatus")
+    @POST("api/v2/order/getSingleOrderStatus")
     Call<TradeItOrderStatusResponse> getSingleOrderStatus(@Body TradeItGetSingleOrderStatusRequest request);
 
-    @POST("/api/v2/order/cancelOrder")
+    @POST("api/v2/order/cancelOrder")
     Call<TradeItOrderStatusResponse> cancelOrder(@Body TradeItCancelOrderRequest request);
 
-    @POST("/api/v2/account/getAllTransactionsHistory")
+    @POST("api/v2/account/getAllTransactionsHistory")
     Call<TradeItGetAllTransactionsHistoryResponse> getAllTransactionsHistory(@Body TradeItGetAllTransactionsHistoryRequest request);
 }


### PR DESCRIPTION
Tested running integration tests:
- with baseURL: https://ems.qa.tradingticket.com/abc/def/ :
 request path generated = https://ems.qa.tradingticket.com/abc/def/api/v2/user/getOAuthLoginPopupUrlForMobile
- with our current base url: https://ems.qa.tradingticket.com/
 request path generated = https://ems.qa.tradingticket.com/api/v2/user/getOAuthLoginPopupUrlForMobile and tests are still working