### PR TITLE
[#150424652] Fix TLS issue

### DIFF
--- a/src/main/java/it/trade/api/TradeItApiClient.java
+++ b/src/main/java/it/trade/api/TradeItApiClient.java
@@ -29,7 +29,6 @@ public class TradeItApiClient {
     protected String sessionToken;
     protected TradeItEnvironment environment;
     protected String apiKey;
-    protected boolean forceTLS12;
 
     public TradeItApiClient(String apiKey, TradeItEnvironment environment) {
         this(apiKey, environment, null, false);

--- a/src/main/java/it/trade/api/TradeItApiClient.java
+++ b/src/main/java/it/trade/api/TradeItApiClient.java
@@ -1,7 +1,7 @@
 package it.trade.api;
 
 
-import it.trade.factory.Tls12SocketFactory;
+import it.trade.factory.TLS12SocketFactory;
 import it.trade.model.TradeItErrorResult;
 import it.trade.model.callback.AuthenticationCallback;
 import it.trade.model.callback.DefaultCallbackWithErrorHandling;
@@ -65,7 +65,7 @@ public class TradeItApiClient {
         }
 
         if (forceTLS12) {
-            Tls12SocketFactory.enableTls12(httpClientBuilder);
+            TLS12SocketFactory.enableTLS12(httpClientBuilder);
         }
 
 //        httpClientBuilder.networkInterceptors().add(new LoggingInterceptor()); //uncomment if you want some request/response logs

--- a/src/main/java/it/trade/api/TradeItApiClient.java
+++ b/src/main/java/it/trade/api/TradeItApiClient.java
@@ -65,7 +65,7 @@ public class TradeItApiClient {
         }
 
         if (forceTLS12) {
-            httpClientBuilder = Tls12SocketFactory.enableTls12(httpClientBuilder);
+            Tls12SocketFactory.enableTls12(httpClientBuilder);
         }
 
 //        httpClientBuilder.networkInterceptors().add(new LoggingInterceptor()); //uncomment if you want some request/response logs

--- a/src/main/java/it/trade/factory/TLS12SocketFactory.java
+++ b/src/main/java/it/trade/factory/TLS12SocketFactory.java
@@ -24,13 +24,13 @@ import java.util.List;
  * @link https://developer.android.com/reference/javax/net/ssl/SSLSocket.html
  * @see SSLSocketFactory
  */
-public class Tls12SocketFactory extends SSLSocketFactory {
+public class TLS12SocketFactory extends SSLSocketFactory {
     private static final String[] TLS_V12_ONLY = {"TLSv1.2"};
-    private static final Logger LOGGER = LoggerFactory.getLogger(Tls12SocketFactory.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TLS12SocketFactory.class);
 
     final SSLSocketFactory delegate;
 
-    public Tls12SocketFactory(SSLSocketFactory base) {
+    public TLS12SocketFactory(SSLSocketFactory base) {
         this.delegate = base;
     }
 
@@ -76,13 +76,13 @@ public class Tls12SocketFactory extends SSLSocketFactory {
         return s;
     }
 
-    public static void enableTls12(OkHttpClient.Builder client) {
+    public static void enableTLS12(OkHttpClient.Builder client) {
         try {
             SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
             X509TrustManager trustManager = getTrustManager();
             sslContext.init(null, new TrustManager[] { trustManager }, null);
 
-            client.sslSocketFactory(new Tls12SocketFactory(sslContext.getSocketFactory()), trustManager);
+            client.sslSocketFactory(new TLS12SocketFactory(sslContext.getSocketFactory()), trustManager);
 
             ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
                     .tlsVersions(TlsVersion.TLS_1_2)

--- a/src/main/java/it/trade/factory/Tls12SocketFactory.java
+++ b/src/main/java/it/trade/factory/Tls12SocketFactory.java
@@ -76,7 +76,7 @@ public class Tls12SocketFactory extends SSLSocketFactory {
         return s;
     }
 
-    public static OkHttpClient.Builder enableTls12(OkHttpClient.Builder client) {
+    public static void enableTls12(OkHttpClient.Builder client) {
         try {
             SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
             X509TrustManager trustManager = getTrustManager();
@@ -97,7 +97,6 @@ public class Tls12SocketFactory extends SSLSocketFactory {
         } catch (Exception exc) {
             LOGGER.error("OkHttpTLSCompat", "Error while setting TLS 1.2", exc);
         }
-        return client;
     }
 
     private static X509TrustManager getTrustManager() {

--- a/src/main/java/it/trade/factory/Tls12SocketFactory.java
+++ b/src/main/java/it/trade/factory/Tls12SocketFactory.java
@@ -1,0 +1,120 @@
+package it.trade.factory;
+
+import okhttp3.ConnectionSpec;
+import okhttp3.OkHttpClient;
+import okhttp3.TlsVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.*;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Enables TLS v1.2 when creating SSLSockets.
+ * <p/>
+ * For some reason, android supports TLS v1.2 from API 16, but enables it by
+ * default only from API 20.
+ * @link https://developer.android.com/reference/javax/net/ssl/SSLSocket.html
+ * @see SSLSocketFactory
+ */
+public class Tls12SocketFactory extends SSLSocketFactory {
+    private static final String[] TLS_V12_ONLY = {"TLSv1.2"};
+    private static final Logger LOGGER = LoggerFactory.getLogger(Tls12SocketFactory.class);
+
+    final SSLSocketFactory delegate;
+
+    public Tls12SocketFactory(SSLSocketFactory base) {
+        this.delegate = base;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return delegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return patch(delegate.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+        return patch(delegate.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return patch(delegate.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket patch(Socket s) {
+        if (s instanceof SSLSocket) {
+            ((SSLSocket) s).setEnabledProtocols(TLS_V12_ONLY);
+        }
+        return s;
+    }
+
+    public static OkHttpClient.Builder enableTls12(OkHttpClient.Builder client) {
+        try {
+            SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+            X509TrustManager trustManager = getTrustManager();
+            sslContext.init(null, new TrustManager[] { trustManager }, null);
+
+            client.sslSocketFactory(new Tls12SocketFactory(sslContext.getSocketFactory()), trustManager);
+
+            ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                    .tlsVersions(TlsVersion.TLS_1_2)
+                    .build();
+
+            List<ConnectionSpec> specs = new ArrayList<>();
+            specs.add(cs);
+            specs.add(ConnectionSpec.COMPATIBLE_TLS);
+            specs.add(ConnectionSpec.CLEARTEXT);
+
+            client.connectionSpecs(specs);
+        } catch (Exception exc) {
+            LOGGER.error("OkHttpTLSCompat", "Error while setting TLS 1.2", exc);
+        }
+        return client;
+    }
+
+    private static X509TrustManager getTrustManager() {
+        X509TrustManager trustManager = null;
+        try {
+            TrustManagerFactory  trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init((KeyStore) null);
+            TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+            if (trustManagers.length != 1 || !(trustManagers[0] instanceof X509TrustManager)) {
+                throw new IllegalStateException("Unexpected default trust managers:"
+                        + Arrays.toString(trustManagers));
+            }
+
+            trustManager = (X509TrustManager) trustManagers[0];
+        } catch (Exception e) {
+            LOGGER.error("getTrustManager", "Error while getting a  X509TrustManager", e);
+        }
+        return trustManager;
+    }
+}


### PR DESCRIPTION
For some reason, android supports TLS v1.2 from API 16, but enables it by
default only from API 20